### PR TITLE
remove composer cache

### DIFF
--- a/files/shared/scripts/cleanup.sh
+++ b/files/shared/scripts/cleanup.sh
@@ -8,6 +8,7 @@ apt-get -y purge
 apt-get -y autoremove
 apt-get clean
 rm -rf /tmp/*
+rm -rf /root/.composer/cache
 rm -rf /var/lib/apt/lists/*
 rm -Rf /usr/share/doc
 rm -Rf /usr/share/man


### PR DESCRIPTION
## Proposed Changes
Remove the composer cache folder in the cleanup step to reduce the final layer size. This results in a reduction of 45 MiB.
