### PR TITLE
default yamllint to 120 chars max

### DIFF
--- a/files/yamllint/config
+++ b/files/yamllint/config
@@ -1,0 +1,8 @@
+---
+extends: default
+rules:
+  line-length:
+    level: warning
+    max: 120
+    allow-non-breakable-words: true
+    allow-non-breakable-inline-mappings: true

--- a/images/mpc/Dockerfile
+++ b/images/mpc/Dockerfile
@@ -9,6 +9,7 @@ ENV INSTALL_GEM "rubocop"
 
 ADD files/shared/scripts/*.sh /tmp/shared/scripts/
 ADD files/mpc/.remarkrc /root/.remarkrc
+ADD files/yamllint /root/.config/yamllint
 
 RUN \
     bash /tmp/shared/scripts/install-upgrade-apt-packages.sh && \


### PR DESCRIPTION
## Proposed Changes

Change de default line length rules  from 80 chars to 120 chars and allow long unbreakable lines
This resolving most linting errors in our gitlab-ci.yml files

