### PR TITLE
DEVOPS-531 Add python-six to the required packages, required for pydocstyle

### DIFF
--- a/images/mpc/Dockerfile
+++ b/images/mpc/Dockerfile
@@ -2,7 +2,7 @@ FROM dealerdirect/debian:jessie
 MAINTAINER Dealerdirect <opensource@dealerdirect.nl>
 
 ENV INSTALL_APT_BUILD_DEPS "python-pip build-essential python-dev"
-ENV INSTALL_APT "php5-cli php5-mcrypt php5-mysql php5-intl ruby libxml2-utils aspell gettext mysql-client"
+ENV INSTALL_APT "php5-cli php5-mcrypt php5-mysql php5-intl ruby libxml2-utils aspell gettext mysql-client python-six"
 ENV INSTALL_PIP "yamllint flake8 pydocstyle"
 ENV INSTALL_NPM "jsonlint editorconfig-tools alex markdown-spellcheck remark-cli remark-lint remark-lint-books-links remark-lint-no-empty-sections remark-lint-no-url-trailing-slash remark-validate-links remark-preset-lint-dealerdirect"
 ENV INSTALL_GEM "rubocop"


### PR DESCRIPTION
## Proposed Changes
add python-six to the installation dependencies , fixes error with pydocstyle

## Related Issues
```
from pydocstyle.cli import main
File "/usr/local/lib/python2.7/dist-packages/pydocstyle/_init_.py", line 1, in <module>
from .checker import check
File "/usr/local/lib/python2.7/dist-packages/pydocstyle/checker.py", line 13, in <module>
from .parser import (Package, Module, Class, NestedClass, Definition, AllError,
File "/usr/local/lib/python2.7/dist-packages/pydocstyle/parser.py", line 4, in <module>
import six
ImportError: No module named six
ERROR: Job failed: exit code 1
```